### PR TITLE
[nrf-ble-driver] Fix incorrect tag, version number & compilation with gcc-11.2.0

### DIFF
--- a/ports/nrf-ble-driver/portfile.cmake
+++ b/ports/nrf-ble-driver/portfile.cmake
@@ -15,6 +15,7 @@ vcpkg_from_github(
     PATCHES
         001-arm64-support.patch
         support-arm64-osx.diff # from https://github.com/NordicSemiconductor/pc-ble-driver/pull/271
+        gcc-11.2.0-compilation.patch # from https://github.com/NordicSemiconductor/pc-ble-driver/pull/272
 )
 
 # Ensure that git is found within CMakeLists.txt by appending vcpkg's git executable dirpath to $PATH.

--- a/ports/nrf-ble-driver/portfile.cmake
+++ b/ports/nrf-ble-driver/portfile.cmake
@@ -9,8 +9,8 @@ endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO NordicSemiconductor/pc-ble-driver
-    REF v4.1.4
-    SHA512 8f35e757dddc27c9b11cdb3b9920562bbe09ceac715d65957e56ec8479e8ffedf12df2f976e484ed0d24b9325d9ef2b8ad6576cccefd2de8d7fa6fa8d58b03e5
+    REF v${VERSION}-hex
+    SHA512 1e8b5882aa3754a29a8f0ec11b8e70390db7ddf7bc50e1318adaaf4cd1ba2b787129d8003f8076ad39c35ec887ef3aeadbcb23fa5100b2be24956d118370cb84
     HEAD_REF master
     PATCHES
         001-arm64-support.patch
@@ -35,8 +35,8 @@ vcpkg_cmake_configure(
     OPTIONS
         -DDISABLE_EXAMPLES=ON
         -DDISABLE_TESTS=ON
-        -DNRF_BLE_DRIVER_VERSION=4.1.2
-        -DCONNECTIVITY_VERSION=4.1.2
+        -DNRF_BLE_DRIVER_VERSION=${VERSION}
+        -DCONNECTIVITY_VERSION=${VERSION}
         ${OPTIONS}
     MAYBE_UNUSED_VARIABLES
         DISABLE_EXAMPLES

--- a/ports/nrf-ble-driver/vcpkg.json
+++ b/ports/nrf-ble-driver/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "nrf-ble-driver",
   "version": "4.1.4",
+  "port-version": 1,
   "description": "BLE driver is a library for Bluetooth Low Energy communication using Nordic Semiconductor development kits.",
   "homepage": "https://github.com/NordicSemiconductor/pc-ble-driver",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5690,7 +5690,7 @@
     },
     "nrf-ble-driver": {
       "baseline": "4.1.4",
-      "port-version": 0
+      "port-version": 1
     },
     "nspr": {
       "baseline": "4.35",

--- a/versions/n-/nrf-ble-driver.json
+++ b/versions/n-/nrf-ble-driver.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "42466a97f2a1d27eef0d22a0e67d4fa709877b3d",
+      "version": "4.1.4",
+      "port-version": 1
+    },
+    {
       "git-tree": "f7eb0b4a2be63dfe15611d96725869023f7b438c",
       "version": "4.1.4",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] SHA512s are updated for each updated download
- [x] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.